### PR TITLE
Implement 'have_count' matcher.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod prelude {
     pub use core::{expect, ActualValue, Matcher};
     pub use matchers::{be_equal_to, be_less_than, be_less_or_equal_to, be_greater_than,
                        be_greater_or_equal_to, be_true, be_false, be_some, BeSome, be_none, be_ok,
-                       BeOk, be_err, BeErr, be_close_to, BeCloseTo, be_empty};
+                       BeOk, be_err, BeErr, be_close_to, BeCloseTo, be_empty, have_count};
 }
 
 pub mod core;

--- a/src/matchers/count.rs
+++ b/src/matchers/count.rs
@@ -1,0 +1,33 @@
+
+use core::{Matcher, Join};
+
+/// A matcher for `have_count` assertions.
+pub struct HaveCount {
+    count: usize,
+}
+
+/// Returns new `HaveCount` matcher.
+pub fn have_count(c: usize) -> HaveCount {
+    HaveCount { count: c }
+}
+
+impl<A, T> Matcher<A, ()> for HaveCount where A: ExactSizeIterator<Item = T> {
+    fn failure_message(&self, join: Join, actual: &A) -> String {
+        format!("expected {} have count {}, got {}", join, self.count, actual.len())
+    }
+
+    fn matches(&self, actual: &A) -> bool {
+        actual.len() == self.count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::have_count;
+    use core::{Matcher, Join};
+
+    #[test]
+    fn test_have_count() {
+        assert!(have_count(3).matches(&vec![0, 0, 0].iter()));
+    }
+}

--- a/src/matchers/mod.rs
+++ b/src/matchers/mod.rs
@@ -9,6 +9,7 @@ pub use self::option::{be_some, BeSome, be_none, BeNone};
 pub use self::result::{be_ok, BeOk, be_err, BeErr};
 pub use self::floats::{be_close_to, BeCloseTo};
 pub use self::empty::{be_empty, BeEmpty};
+pub use self::count::{have_count, HaveCount};
 
 mod partial_eq;
 mod partial_ord;
@@ -17,3 +18,4 @@ mod option;
 mod result;
 mod floats;
 mod empty;
+mod count;

--- a/tests/count.rs
+++ b/tests/count.rs
@@ -1,0 +1,14 @@
+
+#[macro_use(expect)]
+extern crate expectest;
+use expectest::prelude::*;
+
+#[test]
+fn to_have_count_3() {
+    expect!(vec![1, 2, 3].iter()).to(have_count(3));
+}
+
+#[test]
+fn to_have_count_0() {
+    expect!(Vec::<u32>::new().iter()).to(have_count(0));
+}

--- a/tests/count.rs
+++ b/tests/count.rs
@@ -4,11 +4,33 @@ extern crate expectest;
 use expectest::prelude::*;
 
 #[test]
-fn to_have_count_3() {
+fn vec_to_have_count_3() {
     expect!(vec![1, 2, 3].iter()).to(have_count(3));
 }
 
 #[test]
-fn to_have_count_0() {
+fn vec_to_have_count_0() {
     expect!(Vec::<u32>::new().iter()).to(have_count(0));
+}
+
+#[test]
+#[should_panic]
+fn vec_to_have_count_3_should_panic() {
+    expect!(vec![1, 2].iter()).to(have_count(3));
+}
+
+#[test]
+fn string_to_have_count_3() {
+    expect!("abc".chars()).to(have_count(3));
+}
+
+#[test]
+fn string_to_have_count_0() {
+    expect!("".chars()).to(have_count(0));
+}
+
+#[test]
+#[should_panic]
+fn string_to_have_count_3_should_panic() {
+    expect!("abcd".chars()).to(have_count(3));
 }


### PR DESCRIPTION
Desired syntax should be:
```rust
let v = vec![3, 4];
expect!(v.iter()).to(have_count(2));
```