### PR TITLE
Use absolute path to the 'expect' function within 'expect!' macro.

### DIFF
--- a/src/core/join.rs
+++ b/src/core/join.rs
@@ -33,7 +33,6 @@ impl Join {
 #[cfg(test)]
 mod tests {
     use super::Join;
-    use core::expect;
     use matchers::{be_equal_to, be_true, be_false};
 
     #[test]

--- a/src/core/location.rs
+++ b/src/core/location.rs
@@ -32,7 +32,6 @@ impl fmt::Debug for SourceLocation {
 #[cfg(test)]
 mod tests {
     use super::SourceLocation;
-    use core::expect;
     use matchers::be_equal_to;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ extern crate num;
 #[macro_export]
 macro_rules! expect {
     ($e: expr) => (
-        expect($e).location($crate::core::SourceLocation::new(file!(), line!()))
+        $crate::core::expect($e).location($crate::core::SourceLocation::new(file!(), line!()))
     );
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -16,7 +16,6 @@ pub fn is_some_value<T, U>(some: Option<&T>, value: Option<&U>) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::expect;
     use matchers::{be_true, be_false};
 
     #[test]


### PR DESCRIPTION
Closes #9 