### PR TITLE
Run rustfmt.

### DIFF
--- a/src/core/actual.rs
+++ b/src/core/actual.rs
@@ -21,7 +21,10 @@ impl<A> ActualValue<A> {
     /// Also to create a new instance you can use `expect` function or `expect!` macro.
     /// Macro is better because it can save location of a test case in a source code.
     pub fn new(value: A) -> Self {
-        ActualValue { value: value, location: None }
+        ActualValue {
+            value: value,
+            location: None,
+        }
     }
 
     /// Sets a new `SourceLocation`.
@@ -31,22 +34,30 @@ impl<A> ActualValue<A> {
     }
 
     /// Performs assertion matching using `matcher`. Returns a new instance of `TestResult`.
-    pub fn to<M, E>(self, matcher: M) -> TestResult where M: Matcher<A, E> {
+    pub fn to<M, E>(self, matcher: M) -> TestResult
+        where M: Matcher<A, E>
+    {
         self.matching(matcher, Join::To)
     }
 
     /// Performs negation matching using `matcher`. Returns a new instance of `TestResult`.
-    pub fn to_not<M, E>(self, matcher: M) -> TestResult where M: Matcher<A, E> {
+    pub fn to_not<M, E>(self, matcher: M) -> TestResult
+        where M: Matcher<A, E>
+    {
         self.matching(matcher, Join::ToNot)
     }
 
     /// Performs negation matching using `matcher`. Returns a new instance of `TestResult`.
-    pub fn not_to<M, E>(self, matcher: M) -> TestResult where M: Matcher<A, E> {
+    pub fn not_to<M, E>(self, matcher: M) -> TestResult
+        where M: Matcher<A, E>
+    {
         self.matching(matcher, Join::NotTo)
     }
 
     /// Performs matching using `matcher` and `join`. Returns a new instance of `TestResult`.
-    fn matching<M, E>(self, matcher: M, join: Join) -> TestResult where M: Matcher<A, E> {
+    fn matching<M, E>(self, matcher: M, join: Join) -> TestResult
+        where M: Matcher<A, E>
+    {
         let success = if join.is_assertion() {
             matcher.matches(&self.value)
         } else {

--- a/src/core/location.rs
+++ b/src/core/location.rs
@@ -13,7 +13,10 @@ pub struct SourceLocation {
 impl SourceLocation {
     /// Creates a new instance of `SourceLocation` using `file` and `line`.
     pub fn new(file: &'static str, line: u32) -> SourceLocation {
-        SourceLocation { file: file, line: line }
+        SourceLocation {
+            file: file,
+            line: line,
+        }
     }
 }
 

--- a/src/core/result.rs
+++ b/src/core/result.rs
@@ -20,7 +20,11 @@ impl TestResult {
     /// Creates a new instance of `TestResult` with a `Failure` variant using message
     /// and location.
     pub fn new_failure(message: String, location: Option<SourceLocation>) -> Self {
-        TestResult::Failure(Failure { should_panic: true, message: message, location: location })
+        TestResult::Failure(Failure {
+            should_panic: true,
+            message: message,
+            location: location,
+        })
     }
 
     /// Asserts that `message` is equal to the failure message.

--- a/src/matchers/bool.rs
+++ b/src/matchers/bool.rs
@@ -44,25 +44,29 @@ mod tests {
 
     #[test]
     fn test_be_true_message() {
-        expect(1 == 0).to(be_true())
+        expect(1 == 0)
+            .to(be_true())
             .assert_eq_message("expected to be true");
     }
 
     #[test]
     fn test_not_to_be_true_message() {
-        expect(0 == 0).not_to(be_true())
+        expect(0 == 0)
+            .not_to(be_true())
             .assert_eq_message("expected not to be true");
     }
 
     #[test]
     fn test_be_false_message() {
-        expect(0 == 0).to(be_false())
+        expect(0 == 0)
+            .to(be_false())
             .assert_eq_message("expected to be false");
     }
 
     #[test]
     fn test_not_to_be_false_message() {
-        expect(0 == 1).not_to(be_false())
+        expect(0 == 1)
+            .not_to(be_false())
             .assert_eq_message("expected not to be false")
     }
 }

--- a/src/matchers/count.rs
+++ b/src/matchers/count.rs
@@ -15,7 +15,9 @@ impl<A, T> Matcher<A, ()> for HaveCount where A: Iterator<Item = T> + Clone {
     fn failure_message(&self, join: Join, actual: &A) -> String {
         if join.is_assertion() {
             format!("expected {} have count <{}>, got <{}>",
-                join, self.count, actual.clone().count())
+                    join,
+                    self.count,
+                    actual.clone().count())
         } else {
             format!("expected {} have count <{}>", join, self.count)
         }
@@ -33,13 +35,15 @@ mod tests {
 
     #[test]
     fn test_to_have_count_2_message() {
-        expect("abc".chars()).to(have_count(2))
+        expect("abc".chars())
+            .to(have_count(2))
             .assert_eq_message("expected to have count <2>, got <3>");
     }
 
     #[test]
     fn test_not_to_have_count_3_message() {
-        expect("abc".chars()).not_to(have_count(3))
+        expect("abc".chars())
+            .not_to(have_count(3))
             .assert_eq_message("expected not to have count <3>")
     }
 }

--- a/src/matchers/empty.rs
+++ b/src/matchers/empty.rs
@@ -32,13 +32,15 @@ mod tests {
 
     #[test]
     fn be_empty_str_failure_message() {
-        expect("hello").to(be_empty())
+        expect("hello")
+            .to(be_empty())
             .assert_eq_message("expected to be empty, got <\"hello\">");
     }
 
     #[test]
     fn to_not_be_empty_str_failure_message() {
-        expect("").to_not(be_empty())
+        expect("")
+            .to_not(be_empty())
             .assert_eq_message("expected to not be empty");
     }
 }

--- a/src/matchers/floats.rs
+++ b/src/matchers/floats.rs
@@ -13,7 +13,10 @@ pub struct BeCloseTo<E> {
 pub fn be_close_to<E>(expected: E) -> BeCloseTo<E>
     where E: Float
 {
-    BeCloseTo { expected: expected, delta: num::traits::cast(0.001).unwrap() }
+    BeCloseTo {
+        expected: expected,
+        delta: num::traits::cast(0.001).unwrap(),
+    }
 }
 
 impl<E> BeCloseTo<E> {
@@ -27,7 +30,10 @@ impl<E> BeCloseTo<E> {
 impl<E> Matcher<E, E> for BeCloseTo<E> where E: Float + fmt::Debug {
     fn failure_message(&self, join: Join, actual: &E) -> String {
         format!("expected {} be close to <{:?}> ±{:?}, got <{:?}>",
-            join, self.expected, self.delta, actual)
+                join,
+                self.expected,
+                self.delta,
+                actual)
     }
 
     fn matches(&self, actual: &E) -> bool {
@@ -46,19 +52,22 @@ mod tests {
 
     #[test]
     fn close_to_one_failure_message() {
-        expect(0.0).to(be_close_to(1.0))
+        expect(0.0)
+            .to(be_close_to(1.0))
             .assert_eq_message("expected to be close to <1> ±0.001, got <0>");
     }
 
     #[test]
     fn to_not_be_close_to_one_failure_message() {
-        expect(0.9991).not_to(be_close_to(1.0))
+        expect(0.9991)
+            .not_to(be_close_to(1.0))
             .assert_eq_message("expected not to be close to <1> ±0.001, got <0.9991>");
     }
 
     #[test]
     fn close_to_one_delta_failure_message() {
-        expect(0.0).to(be_close_to(1.0).delta(0.1))
+        expect(0.0)
+            .to(be_close_to(1.0).delta(0.1))
             .assert_eq_message("expected to be close to <1> ±0.1, got <0>");
     }
 }

--- a/src/matchers/option.rs
+++ b/src/matchers/option.rs
@@ -30,7 +30,9 @@ impl<A, E> Matcher<Option<A>, Option<E>> for BeSome<E>
             format!("expected {} be Some, got <{:?}>", join, actual)
         } else {
             format!("expected {} be equal to <{:?}>, got <{:?}>",
-                join, self.expected, actual)
+                    join,
+                    self.expected,
+                    actual)
         }
     }
 
@@ -67,25 +69,29 @@ mod tests {
 
     #[test]
     fn be_some_failure_message() {
-        expect(None::<u8>).to(be_some())
+        expect(None::<u8>)
+            .to(be_some())
             .assert_eq_message("expected to be Some, got <None>");
     }
 
     #[test]
     fn be_some_value_failure_message_1() {
-        expect(None::<u8>).to(be_some().value(1))
+        expect(None::<u8>)
+            .to(be_some().value(1))
             .assert_eq_message("expected to be equal to <Some(1)>, got <None>");
     }
 
     #[test]
     fn be_some_value_failure_message_2() {
-        expect(Some(2)).to(be_some().value(1))
+        expect(Some(2))
+            .to(be_some().value(1))
             .assert_eq_message("expected to be equal to <Some(1)>, got <Some(2)>");
     }
 
     #[test]
     fn be_none_failure_message() {
-        expect(Some(2)).to(be_none())
+        expect(Some(2))
+            .to(be_none())
             .assert_eq_message("expected to be None, got <Some(2)>");
     }
 }

--- a/src/matchers/partial_eq.rs
+++ b/src/matchers/partial_eq.rs
@@ -20,7 +20,10 @@ impl<A, E> Matcher<A, E> for BeEqualTo<E>
 
     fn failure_message(&self, join: Join, actual: &A) -> String {
         if join.is_assertion() {
-            format!("expected {} be equal to <{:?}>, got <{:?}>", join, self.expected, actual)
+            format!("expected {} be equal to <{:?}>, got <{:?}>",
+                    join,
+                    self.expected,
+                    actual)
         } else {
             format!("expected {} be equal to <{:?}>", join, self.expected)
         }
@@ -38,13 +41,15 @@ mod tests {
 
     #[test]
     fn be_equal_to_failure_message() {
-        expect(2).to(be_equal_to(1))
+        expect(2)
+            .to(be_equal_to(1))
             .assert_eq_message("expected to be equal to <1>, got <2>");
     }
 
     #[test]
     fn to_not_be_equal_to_failure_message() {
-        expect(1).to_not(be_equal_to(1))
+        expect(1)
+            .to_not(be_equal_to(1))
             .assert_eq_message("expected to not be equal to <1>");
     }
 }

--- a/src/matchers/partial_ord.rs
+++ b/src/matchers/partial_ord.rs
@@ -10,7 +10,10 @@ pub struct PartialOrder<E> {
 
 impl<E> PartialOrder<E> {
     fn new(expected: E, order: Order) -> PartialOrder<E> {
-        PartialOrder { expected: expected, order: order }
+        PartialOrder {
+            expected: expected,
+            order: order,
+        }
     }
 }
 
@@ -21,7 +24,10 @@ impl<A, E> Matcher<A, E> for PartialOrder<E>
 
     fn failure_message(&self, join: Join, actual: &A) -> String {
         format!("expected {} be {} <{:?}>, got <{:?}>",
-            join, self.order, self.expected, actual)
+                join,
+                self.order,
+                self.expected,
+                actual)
     }
 
     fn matches(&self, actual: &A) -> bool {
@@ -44,7 +50,7 @@ pub fn be_less_or_equal_to<E>(expected: E) -> PartialOrder<E> {
     PartialOrder::new(expected, Order::LessOrEqualTo)
 }
 
-//// Returns a new `PartialOrder` (greater than) matcher.
+/// Returns a new `PartialOrder` (greater than) matcher.
 pub fn be_greater_than<E>(expected: E) -> PartialOrder<E> {
     PartialOrder::new(expected, Order::GreaterThan)
 }
@@ -80,25 +86,29 @@ mod tests {
 
     #[test]
     fn be_less_than_one_failure_message() {
-        expect(1).to(be_less_than(1))
+        expect(1)
+            .to(be_less_than(1))
             .assert_eq_message("expected to be less than <1>, got <1>");
     }
 
     #[test]
     fn be_less_or_equal_to_one_failure_message() {
-        expect(2).to(be_less_or_equal_to(1))
+        expect(2)
+            .to(be_less_or_equal_to(1))
             .assert_eq_message("expected to be less or equal to <1>, got <2>");
     }
 
     #[test]
     fn be_greater_than_zero_failure_message() {
-        expect(0).to(be_greater_than(0))
+        expect(0)
+            .to(be_greater_than(0))
             .assert_eq_message("expected to be greater than <0>, got <0>");
     }
 
     #[test]
     fn be_greater_or_equal_to_zero_failure_message() {
-        expect(-1).to(be_greater_or_equal_to(0))
+        expect(-1)
+            .to(be_greater_or_equal_to(0))
             .assert_eq_message("expected to be greater or equal to <0>, got <-1>");
     }
 }

--- a/src/matchers/result.rs
+++ b/src/matchers/result.rs
@@ -100,49 +100,57 @@ mod tests {
 
     #[test]
     fn be_ok_failure_message() {
-        expect(err_result("error")).to(be_ok())
+        expect(err_result("error"))
+            .to(be_ok())
             .assert_eq_message("expected to be <Ok>, got <Err(\"error\")>");
     }
 
     #[test]
     fn be_ok_value_failure_message() {
-        expect(err_result("error")).to(be_ok().value(5))
+        expect(err_result("error"))
+            .to(be_ok().value(5))
             .assert_eq_message("expected to be <Ok(5)>, got <Err(\"error\")>");
     }
 
     #[test]
     fn to_not_be_ok_value_failure_message() {
-        expect(ok_result(5)).to_not(be_ok().value(5))
+        expect(ok_result(5))
+            .to_not(be_ok().value(5))
             .assert_eq_message("expected to not be <Ok(5)>");
     }
 
     #[test]
     fn to_not_be_ok_failure_message() {
-        expect(ok_result(5)).to_not(be_ok())
+        expect(ok_result(5))
+            .to_not(be_ok())
             .assert_eq_message("expected to not be <Ok>, got <Ok(5)>");
     }
 
     #[test]
     fn be_err_failure_message() {
-        expect(ok_result(2)).to(be_err::<&str>())
+        expect(ok_result(2))
+            .to(be_err::<&str>())
             .assert_eq_message("expected to be <Err>, got <Ok(2)>");
     }
 
     #[test]
     fn be_err_value_failure_message() {
-        expect(ok_result(2)).to(be_err().value("error"))
+        expect(ok_result(2))
+            .to(be_err().value("error"))
             .assert_eq_message("expected to be <Err(\"error\")>, got <Ok(2)>");
     }
 
     #[test]
     fn to_not_be_err_value_failure_message() {
-        expect(err_result("error")).to_not(be_err().value("error"))
+        expect(err_result("error"))
+            .to_not(be_err().value("error"))
             .assert_eq_message("expected to not be <Err(\"error\")>");
     }
 
     #[test]
     fn to_not_be_err_failure_message() {
-        expect(err_result("error")).to_not(be_err::<&str>())
+        expect(err_result("error"))
+            .to_not(be_err::<&str>())
             .assert_eq_message("expected to not be <Err>, got <Err(\"error\")>");
     }
 }


### PR DESCRIPTION
- Run rustfmt.
- Remove redundant slash in the doc comment.