### PR TITLE
Change printing to closely match rust's unit testing behavior.

### DIFF
--- a/src/core/actual.rs
+++ b/src/core/actual.rs
@@ -66,7 +66,8 @@ impl<A> ActualValue<A> {
         if success {
             TestResult::new_success()
         } else {
-            TestResult::new_failure(matcher.failure_message(join, &self.value), self.location)
+            let message = matcher.failure_message(join, &self.value);
+            TestResult::new_failure(message, self.location)
         }
     }
 }

--- a/src/core/location.rs
+++ b/src/core/location.rs
@@ -8,21 +8,24 @@ pub struct SourceLocation {
     pub file: &'static str,
     /// Number of line in the file.
     pub line: u32,
+    /// Number of column in the line.
+    pub column: u32,
 }
 
 impl SourceLocation {
     /// Creates a new instance of `SourceLocation` using `file` and `line`.
-    pub fn new(file: &'static str, line: u32) -> SourceLocation {
+    pub fn new(file: &'static str, line: u32, column: u32) -> SourceLocation {
         SourceLocation {
             file: file,
             line: line,
+            column: column,
         }
     }
 }
 
 impl fmt::Display for SourceLocation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}:{}", self.file, self.line)
+        write!(f, "{}:{}:{}", self.file, self.line, self.column)
     }
 }
 
@@ -39,7 +42,7 @@ mod tests {
 
     #[test]
     fn location_should_display_correct_text() {
-        let location = SourceLocation::new("path/to/file.rs", 9);
-        expect!(location.to_string()).to(be_equal_to("path/to/file.rs:9"));
+        let location = SourceLocation::new("path/to/file.rs", 9, 8);
+        expect!(location.to_string()).to(be_equal_to("path/to/file.rs:9:8"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,9 +186,10 @@ extern crate core as rust_core;
 /// Provides a file name and a line number for a failed test case.
 #[macro_export]
 macro_rules! expect {
-    ($e: expr) => (
-        $crate::core::expect($e).location($crate::core::SourceLocation::new(file!(), line!()))
-    );
+    ($e: expr) => ({
+        let location = $crate::core::SourceLocation::new(file!(), line!(), column!());
+        $crate::core::expect($e).location(location)
+    });
 }
 
 pub mod prelude {


### PR DESCRIPTION
Changed printing to closely match rust's unit testing behavior.

As such instead of spilling its guts onto `std::io::stdout` the `Failure` struct will now neatly embed its failure message into its `panic!(…)`.

As such `expect!(…)` now produces:

```
---- core::result::tests::fails stdout ----
	thread 'tests::fails' panicked at 'assertion failed: `expected to be equal to <1>, got <0>``', src/test.rs:10:12
```

… on nightly, and …

```
---- core::result::tests::fails stdout ----
	thread 'tests::fails' panicked at 'assertion failed: `expected to be equal to <1>, got <0>``, src/test.rs:10:12', src/core/result.rs:82:12
```

… on stable, while `expect(…)` produces …

```
---- tests::fails stdout ----
	thread 'tests::fails' panicked at 'assertion failed: `expected to be equal to <1>, got <0>``', src/test.rs:10:12
```

… for …

```rust
#[test]
fn fails() {
    expect(0).to(be_equal_to(1));
}
```

This now matches Rust's own standard behavior enough to provide a consistent experience even when mixing `expect!(…)` and `assert!(…)` or `assert_eq!(…)`/`assert_ne!(…)` …

… which produces …

```
---- tests::fails stdout ----
	thread 'tests::fails' panicked at 'assertion failed: `(left == right)`, left: `0`, right: `1`', src/test.rs:10:12
```

… for …

```rust
#[test]
fn fails() {
    assert_eq!(0, 1);
}
```

---

Especially the "spilling its guts onto `std::io::stdout`" of `Failure` had been a blocker for me for adding integration support for [zummenix/expectest](https://github.com/zummenix/expectest) to [mackwic/rspec](https://github.com/mackwic/rspec).